### PR TITLE
Add guest-based search and expanded booking form

### DIFF
--- a/includes/cpt.php
+++ b/includes/cpt.php
@@ -98,7 +98,9 @@ function rsv_render_booking_meta($post){
     $ci = esc_attr(get_post_meta($post->ID,'rsv_check_in',true));
     $co = esc_attr(get_post_meta($post->ID,'rsv_check_out',true));
     $name = esc_attr(get_post_meta($post->ID,'rsv_guest_name',true));
+    $surname = esc_attr(get_post_meta($post->ID,'rsv_guest_surname',true));
     $email = esc_attr(get_post_meta($post->ID,'rsv_guest_email',true));
+    $phone = esc_attr(get_post_meta($post->ID,'rsv_guest_phone',true));
     $pay = esc_attr(get_post_meta($post->ID,'rsv_payment_status',true));
     $types = get_posts(['post_type'=>'rsv_accomm','post_status'=>'publish','numberposts'=>-1]);
     ?>
@@ -113,7 +115,9 @@ function rsv_render_booking_meta($post){
     <p><label><?php esc_html_e('Check-in','reeserva');?> <input type="date" name="rsv_check_in" value="<?php echo $ci;?>"></label></p>
     <p><label><?php esc_html_e('Check-out','reeserva');?> <input type="date" name="rsv_check_out" value="<?php echo $co;?>"></label></p>
     <p><label><?php esc_html_e('Guest name','reeserva');?> <input type="text" name="rsv_guest_name" value="<?php echo $name;?>"></label></p>
+    <p><label><?php esc_html_e('Guest surname','reeserva');?> <input type="text" name="rsv_guest_surname" value="<?php echo $surname;?>"></label></p>
     <p><label><?php esc_html_e('Guest email','reeserva');?> <input type="email" name="rsv_guest_email" value="<?php echo $email;?>"></label></p>
+    <p><label><?php esc_html_e('Guest phone','reeserva');?> <input type="text" name="rsv_guest_phone" value="<?php echo $phone;?>"></label></p>
     <p><label><?php esc_html_e('Payment status','reeserva');?> <input type="text" name="rsv_payment_status" value="<?php echo $pay;?>"></label></p>
     <?php
 }
@@ -123,7 +127,9 @@ add_action('save_post_rsv_booking', function($post_id){
     update_post_meta($post_id,'rsv_check_in', sanitize_text_field($_POST['rsv_check_in'] ?? ''));
     update_post_meta($post_id,'rsv_check_out', sanitize_text_field($_POST['rsv_check_out'] ?? ''));
     update_post_meta($post_id,'rsv_guest_name', sanitize_text_field($_POST['rsv_guest_name'] ?? ''));
+    update_post_meta($post_id,'rsv_guest_surname', sanitize_text_field($_POST['rsv_guest_surname'] ?? ''));
     update_post_meta($post_id,'rsv_guest_email', sanitize_email($_POST['rsv_guest_email'] ?? ''));
+    update_post_meta($post_id,'rsv_guest_phone', sanitize_text_field($_POST['rsv_guest_phone'] ?? ''));
     update_post_meta($post_id,'rsv_payment_status', sanitize_text_field($_POST['rsv_payment_status'] ?? ''));
 });
 
@@ -134,14 +140,19 @@ add_filter('the_content', function($content){
     $ci = get_post_meta(get_the_ID(),'rsv_check_in',true);
     $co = get_post_meta(get_the_ID(),'rsv_check_out',true);
     $name = get_post_meta(get_the_ID(),'rsv_guest_name',true);
+    $surname = get_post_meta(get_the_ID(),'rsv_guest_surname',true);
     $email = get_post_meta(get_the_ID(),'rsv_guest_email',true);
+    $phone = get_post_meta(get_the_ID(),'rsv_guest_phone',true);
     $pay = get_post_meta(get_the_ID(),'rsv_payment_status',true);
     $out = '<h3>'.esc_html__('Booking details','reeserva').'</h3><ul class="rsv-booking-details">';
     if($ac) $out .= '<li><strong>'.esc_html__('Accommodation','reeserva').':</strong> '.esc_html(get_the_title($ac)).'</li>';
     if($ci) $out .= '<li><strong>'.esc_html__('Check-in','reeserva').':</strong> '.esc_html($ci).'</li>';
     if($co) $out .= '<li><strong>'.esc_html__('Check-out','reeserva').':</strong> '.esc_html($co).'</li>';
-    if($name) $out .= '<li><strong>'.esc_html__('Guest','reeserva').':</strong> '.esc_html($name).'</li>';
+    if($name || $surname){
+        $out .= '<li><strong>'.esc_html__('Guest','reeserva').':</strong> '.esc_html(trim($name.' '.$surname)).'</li>';
+    }
     if($email) $out .= '<li><strong>'.esc_html__('Email','reeserva').':</strong> '.esc_html($email).'</li>';
+    if($phone) $out .= '<li><strong>'.esc_html__('Phone','reeserva').':</strong> '.esc_html($phone).'</li>';
     if($pay) $out .= '<li><strong>'.esc_html__('Payment','reeserva').':</strong> '.esc_html($pay).'</li>';
     $out .= '</ul>';
     return $content.$out;

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -29,6 +29,22 @@ function rsv_checkout_url(){
 function rsv_date_range_overlaps($startA, $endA, $startB, $endB){
     return (strtotime($startA) < strtotime($endB)) && (strtotime($endA) > strtotime($startB));
 }
+function rsv_is_accomm_available($accomm_id, $start, $end){
+    $bookings = get_posts([
+        'post_type'   => 'rsv_booking',
+        'numberposts' => -1,
+        'post_status' => ['publish','confirmed','pending'],
+        'meta_query'  => [
+            ['key'=>'rsv_booking_accomm','value'=>$accomm_id,'compare'=>'=']
+        ]
+    ]);
+    foreach($bookings as $bk){
+        $bci = get_post_meta($bk->ID,'rsv_check_in',true);
+        $bco = get_post_meta($bk->ID,'rsv_check_out',true);
+        if($bci && $bco && rsv_date_range_overlaps($start,$end,$bci,$bco)) return false;
+    }
+    return true;
+}
 function rsv_make_ics($args){
     $uid = uniqid('rsv_', true).'@'.parse_url(home_url(), PHP_URL_HOST);
     $dtstamp = gmdate('Ymd\THis\Z');


### PR DESCRIPTION
## Summary
- allow searching accommodations by guests and dates with availability filtering
- collect full guest contact details and optional notes during booking
- pass guest data through Stripe and store in booking metadata

## Testing
- `php -l includes/helpers.php`
- `php -l includes/cpt.php`
- `php -l includes/shortcodes.php`
- `php -l includes/payments.php`


------
https://chatgpt.com/codex/tasks/task_e_68a08282b7848332a3147fb74ebd45a0