### PR TITLE
Fix price cell color and reset pricing data

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -17,6 +17,7 @@
 
 /* subtle chips on calendar */
 .fc-event.price-event { z-index:1 !important; position:absolute; top:2px !important; left:4px; right:4px; border:none; background:transparent !important; color:#000 !important; font-weight:600; border-radius:8px; padding:2px 6px; pointer-events:none; }
+.fc-event.price-event .fc-event-main { color:#000 !important; }
 .fc-event.rsv-booking { background:#dc2626 !important; border:none; color:#fff !important; border-radius:6px; z-index:1 !important; pointer-events:none; }
 .fc-daygrid-day-frame { position: relative; min-height:90px; }
 .fc-daygrid-day-events { margin-top:20px; }

--- a/assets/js/admin-calendar.js
+++ b/assets/js/admin-calendar.js
@@ -4,7 +4,8 @@
         nonceBooked = RSV_ADMIN.nonceBooked,
         nonceLoad   = RSV_ADMIN.nonceLoad,
         nonceDay    = RSV_ADMIN.nonceDay,
-        nonceUpdate = RSV_ADMIN.nonceUpdate;
+        nonceUpdate = RSV_ADMIN.nonceUpdate,
+        nonceReset  = RSV_ADMIN.nonceReset;
   const selectEl = document.getElementById('accommodation-select');
   const summaryBody = document.getElementById('summary-body');
   const priceModal = document.getElementById('price-modal');
@@ -21,6 +22,7 @@
   const createBtn = document.getElementById('create-admin-booking');
   const syncBtn = document.getElementById('rsv-sync-ical');
   const syncRes = document.getElementById('rsv-sync-result');
+  const resetBtn = document.getElementById('reset-prices');
 
   let currentType = parseInt(selectEl ? selectEl.value : 0,10);
   let selectedRange = null;
@@ -194,6 +196,19 @@
         if(res && res.success){ syncRes.textContent='Imported '+(res.data && res.data.added ? res.data.added : 0)+' events.'; calendar.refetchEvents(); }
         else { syncRes.textContent='iCal sync failed'; }
       }).catch(()=> syncRes.textContent='Network error');
+    });
+  }
+
+  if(resetBtn){
+    resetBtn.addEventListener('click', ()=>{
+      const form = new FormData();
+      form.append('action','rsv_reset_prices');
+      form.append('nonce',nonceReset);
+      form.append('type_id',currentType);
+      fetch(ajax,{method:'POST',body:form,credentials:'same-origin'}).then(r=>r.json()).then(res=>{
+        if(res && res.success){ calendar.refetchEvents(); }
+        else{ alert('Failed to reset prices'); }
+      }).catch(()=> alert('Network error'));
     });
   }
 })();

--- a/includes/admin-pages.php
+++ b/includes/admin-pages.php
@@ -13,6 +13,7 @@ function rsv_admin_enqueue(){
         'nonceLoad'  => wp_create_nonce('rsv_load_prices'),
         'nonceDay'   => wp_create_nonce('rsv_day_prices'),
         'nonceUpdate'=> wp_create_nonce('rsv_update_price'),
+        'nonceReset' => wp_create_nonce('rsv_reset_prices'),
     ]);
 }
 add_action('admin_enqueue_scripts','rsv_admin_enqueue');
@@ -35,6 +36,8 @@ function rsv_render_calendar(){
         <span id="rsv-sync-result" style="color:#555"></span>
       </div>
       <div id="calendar"></div>
+
+      <button class="button" id="reset-prices"><?php esc_html_e('Reset prices','reeserva');?></button>
 
       <div class="booking-summary">
         <h3><?php esc_html_e('Reserved Dates','reeserva')?></h3>


### PR DESCRIPTION
## Summary
- ensure price events display black text
- overwrite existing prices and support clearing them
- add admin "Reset prices" button for testing

## Testing
- `php -l includes/ajax.php`
- `php -l includes/admin-pages.php`
- `node --check assets/js/admin-calendar.js && echo "JS OK"`

------
https://chatgpt.com/codex/tasks/task_e_68a0a24a4b348332801460663d8afbec