### PR TITLE
Handle empty calendar prices and revamp search form

### DIFF
--- a/assets/css/search.css
+++ b/assets/css/search.css
@@ -1,0 +1,31 @@
+.ehb-search-form{
+  display:flex;
+  gap:12px;
+  flex-wrap:wrap;
+  margin:12px 0;
+  font-family:Arial,sans-serif;
+}
+.ehb-search-form label{
+  display:flex;
+  flex-direction:column;
+  font-size:14px;
+  color:#484848;
+}
+.ehb-search-form input{
+  padding:10px 12px;
+  border:1px solid #ddd;
+  border-radius:8px;
+  font-size:16px;
+}
+.ehb-search-form button{
+  background:#ff385c;
+  color:#fff;
+  border:none;
+  border-radius:8px;
+  padding:10px 16px;
+  font-size:16px;
+  cursor:pointer;
+}
+.ehb-search-form button:hover{
+  background:#e31c5f;
+}

--- a/assets/js/admin-calendar.js
+++ b/assets/js/admin-calendar.js
@@ -154,7 +154,6 @@
         nights: parseInt(r.querySelector('.tier-nights').value,10)||1,
         price:  parseFloat(r.querySelector('.tier-price').value)||0
       }));
-      if(!tiers.length){ alert('Add at least one nights tier'); return; }
       const periods = tiers.map(t=>t.nights);
       const base_prices = tiers.map(t=>t.price);
       const variations = Array.from(varsCt.querySelectorAll('.var-card')).map(card=>{

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded',function(){
+  const form=document.querySelector('.ehb-search-form');
+  if(!form) return;
+  const ci=form.querySelector('input[name="ci"]');
+  const co=form.querySelector('input[name="co"]');
+  [ci,co].forEach(inp=>{
+    if(!inp) return;
+    ['focus','click'].forEach(evt=>{
+      inp.addEventListener(evt,()=>{ if(inp.showPicker) inp.showPicker(); });
+    });
+  });
+  if(ci && co){
+    ci.addEventListener('change',()=>{
+      if(ci.value){
+        const d=new Date(ci.value);
+        d.setDate(d.getDate()+1);
+        co.value=d.toISOString().split('T')[0];
+      }
+    });
+  }
+});

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -3,11 +3,13 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 add_shortcode('rsv_search', function(){
+    wp_enqueue_style('rsv-search', RSV_URL.'assets/css/search.css', [], RSV_VER);
+    wp_enqueue_script('rsv-search', RSV_URL.'assets/js/search.js', [], RSV_VER, true);
     $ci = sanitize_text_field($_GET['ci'] ?? '');
     $co = sanitize_text_field($_GET['co'] ?? '');
     $guests = intval($_GET['guests'] ?? 0);
     ob_start(); ?>
-    <form class="ehb-search-form" method="get" style="display:flex;gap:10px;flex-wrap:wrap;margin:12px 0">
+    <form class="ehb-search-form" method="get">
       <label><?php esc_html_e('Guests','reeserva'); ?> <input type="number" name="guests" value="<?php echo esc_attr($guests); ?>" min="1" required></label>
       <label><?php esc_html_e('Check-in','reeserva'); ?> <input type="date" name="ci" value="<?php echo esc_attr($ci); ?>" required></label>
       <label><?php esc_html_e('Check-out','reeserva'); ?> <input type="date" name="co" value="<?php echo esc_attr($co); ?>" required></label>


### PR DESCRIPTION
## Summary
- Support saving empty price ranges to block dates without prices
- Skip blocked dates in availability checks and loading price events
- Restyle search form and enhance date inputs with auto checkout

## Testing
- `php -l includes/ajax.php`
- `php -l includes/helpers.php`
- `php -l includes/shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0b0b9d88c8332ae51298d06f8d8f4