### PR TITLE
Add front-end admin dashboard shortcode with responsive sidebar

### DIFF
--- a/assets/css/frontend-admin.css
+++ b/assets/css/frontend-admin.css
@@ -1,0 +1,58 @@
+.rsv-admin-dashboard{
+  display:flex;
+  min-height:80vh;
+  font-family:"Helvetica Neue",Arial,sans-serif;
+}
+.rsv-admin-menu-toggle{
+  display:none;
+  position:fixed;
+  top:15px;
+  left:15px;
+  background:#fff;
+  border:1px solid #ddd;
+  border-radius:4px;
+  padding:8px 10px;
+  z-index:1001;
+}
+.rsv-admin-sidebar{
+  width:220px;
+  background:#fff;
+  border-right:1px solid #eee;
+  padding:20px;
+}
+.rsv-admin-sidebar h2{
+  margin-top:0;
+  font-size:1.2rem;
+  color:#FF5A5F;
+}
+.rsv-admin-sidebar nav a{
+  display:block;
+  padding:8px 0;
+  color:#333;
+  text-decoration:none;
+  border-bottom:1px solid #f0f0f0;
+}
+.rsv-admin-sidebar nav a.active{
+  color:#FF5A5F;
+  font-weight:600;
+}
+.rsv-admin-main{
+  flex:1;
+  padding:20px;
+  background:#fafafa;
+}
+@media(max-width:782px){
+  .rsv-admin-dashboard{flex-direction:column;}
+  .rsv-admin-menu-toggle{display:block;}
+  .rsv-admin-sidebar{
+    position:fixed;
+    left:-260px;
+    top:0;
+    height:100%;
+    width:240px;
+    transition:left .3s;
+    z-index:1000;
+  }
+  .rsv-admin-sidebar.open{left:0;box-shadow:2px 0 8px rgba(0,0,0,.15);}
+  .rsv-admin-main{padding:15px;}
+}

--- a/assets/js/frontend-admin.js
+++ b/assets/js/frontend-admin.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded',function(){
+  var sidebar=document.querySelector('.rsv-admin-sidebar');
+  var toggle=document.querySelector('.rsv-admin-menu-toggle');
+  var links=sidebar?sidebar.querySelectorAll('nav a'):[];
+  var sections=document.querySelectorAll('.rsv-admin-section');
+  if(toggle){toggle.addEventListener('click',function(){sidebar.classList.toggle('open');});}
+  links.forEach(function(l){
+    l.addEventListener('click',function(e){
+      e.preventDefault();
+      var target=this.getAttribute('data-section');
+      sections.forEach(function(s){s.style.display=s.id==='rsv-section-'+target?'block':'none';});
+      links.forEach(function(a){a.classList.remove('active');});
+      this.classList.add('active');
+      if(sidebar.classList.contains('open')) sidebar.classList.remove('open');
+    });
+  });
+});

--- a/includes/frontend-admin.php
+++ b/includes/frontend-admin.php
@@ -1,4 +1,33 @@
-
 <?php
 if ( ! defined( 'ABSPATH' ) ) exit;
-/* Placeholder: you can add frontend admin shortcodes later if needed */
+
+function rsv_frontend_admin_assets(){
+    if ( ! current_user_can('manage_options') ) return;
+    if ( function_exists('rsv_admin_enqueue') ) rsv_admin_enqueue();
+    wp_enqueue_style('rsv-frontend-admin', RSV_URL.'assets/css/frontend-admin.css', ['rsv-admin'], RSV_VER);
+    wp_enqueue_script('rsv-frontend-admin', RSV_URL.'assets/js/frontend-admin.js', ['rsv-admin-calendar'], RSV_VER, true);
+}
+
+add_shortcode('rsv_admin_dashboard', function(){
+    if ( ! current_user_can('manage_options') ) return '';
+    rsv_frontend_admin_assets();
+    ob_start(); ?>
+    <div class="rsv-admin-dashboard">
+      <button class="rsv-admin-menu-toggle" aria-label="<?php esc_attr_e('Menu','reeserva');?>">☰</button>
+      <aside class="rsv-admin-sidebar">
+        <h2><?php esc_html_e('Admin','reeserva');?></h2>
+        <nav>
+          <a href="#" class="active" data-section="calendar"><?php esc_html_e('Calendar','reeserva');?></a>
+          <a href="#" data-section="emails"><?php esc_html_e('Emails','reeserva');?></a>
+          <a href="#" data-section="payments"><?php esc_html_e('Payments','reeserva');?></a>
+        </nav>
+      </aside>
+      <div class="rsv-admin-main">
+        <section id="rsv-section-calendar" class="rsv-admin-section"><?php rsv_render_calendar(); ?></section>
+        <section id="rsv-section-emails" class="rsv-admin-section" style="display:none"><?php rsv_render_email_form(); ?></section>
+        <section id="rsv-section-payments" class="rsv-admin-section" style="display:none"><?php rsv_render_payment_form(); ?></section>
+      </div>
+    </div>
+    <?php
+    return ob_get_clean();
+});

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -34,7 +34,7 @@ function rsv_get_payment_settings(){
     return wp_parse_args($s, $defaults);
 }
 
-function rsv_render_email_settings(){
+function rsv_render_email_form(){
     if (!current_user_can('manage_options')) return;
     $s = rsv_get_email_settings();
     if (isset($_POST['rsv_email_save'])){
@@ -51,7 +51,35 @@ function rsv_render_email_settings(){
         update_option('rsv_email_settings',$s);
         echo '<div class="updated"><p>'.esc_html__('Email settings saved.','reeserva').'</p></div>';
     }
+    ?>
+    <form method="post">
+      <?php wp_nonce_field('rsv_email_settings'); ?>
+      <h2><?php esc_html_e('General','reeserva');?></h2>
+      <table class="form-table"><tbody>
+        <tr><th><?php esc_html_e('From name','reeserva');?></th><td><input type="text" name="from_name" value="<?php echo esc_attr($s['from_name']);?>" class="regular-text"></td></tr>
+        <tr><th><?php esc_html_e('From email','reeserva');?></th><td><input type="email" name="from_email" value="<?php echo esc_attr($s['from_email']);?>" class="regular-text"></td></tr>
+      </tbody></table>
+      <h2><?php esc_html_e('Guest email','reeserva');?></h2>
+      <p><label><input type="checkbox" name="guest_enabled" <?php checked($s['guest_enabled']);?>> <?php esc_html_e('Enable guest confirmation email','reeserva');?></label></p>
+      <table class="form-table"><tbody>
+        <tr><th><?php esc_html_e('Subject','reeserva');?></th><td><input type="text" name="guest_subject" value="<?php echo esc_attr($s['guest_subject']);?>" class="regular-text"></td></tr>
+        <tr><th><?php esc_html_e('Body','reeserva');?></th><td><textarea name="guest_body" rows="6" class="large-text code"><?php echo esc_textarea($s['guest_body']);?></textarea></td></tr>
+      </tbody></table>
+      <h2><?php esc_html_e('Admin email','reeserva');?></h2>
+      <p><label><input type="checkbox" name="admin_enabled" <?php checked($s['admin_enabled']);?>> <?php esc_html_e('Enable admin notification email','reeserva');?></label></p>
+      <table class="form-table"><tbody>
+        <tr><th><?php esc_html_e('Subject','reeserva');?></th><td><input type="text" name="admin_subject" value="<?php echo esc_attr($s['admin_subject']);?>" class="regular-text"></td></tr>
+        <tr><th><?php esc_html_e('Body','reeserva');?></th><td><textarea name="admin_body" rows="6" class="large-text code"><?php echo esc_textarea($s['admin_body']);?></textarea></td></tr>
+      </tbody></table>
+      <h2><?php esc_html_e('Footer','reeserva');?></h2>
+      <p><textarea name="footer" rows="3" class="large-text code"><?php echo esc_textarea($s['footer']);?></textarea></p>
+      <p><button type="submit" name="rsv_email_save" class="button button-primary"><?php esc_html_e('Save email settings','reeserva');?></button></p>
+    </form>
+    <?php
+}
 
+function rsv_render_payment_form(){
+    if (!current_user_can('manage_options')) return;
     $p = rsv_get_payment_settings();
     if (isset($_POST['rsv_payment_save'])){
         check_admin_referer('rsv_payment_settings');
@@ -66,7 +94,38 @@ function rsv_render_email_settings(){
         update_option('rsv_payment_settings',$p);
         echo '<div class="updated"><p>'.esc_html__('Payment settings saved.','reeserva').'</p></div>';
     }
+    ?>
+    <form method="post">
+      <?php wp_nonce_field('rsv_payment_settings'); ?>
+      <h2><?php esc_html_e('Stripe','reeserva');?></h2>
+      <p><label><input type="checkbox" name="stripe_enabled" <?php checked($p['stripe_enabled']);?>> <?php esc_html_e('Enable Stripe payments','reeserva');?></label></p>
+      <table class="form-table"><tbody>
+        <tr><th><?php esc_html_e('Currency','reeserva');?></th><td>
+          <select name="currency">
+            <?php foreach(['eur'=>'EUR','usd'=>'USD','gbp'=>'GBP'] as $k=>$v): ?>
+              <option value="<?php echo esc_attr($k);?>" <?php selected($p['currency'],$k);?>><?php echo esc_html($v);?></option>
+            <?php endforeach; ?>
+          </select>
+        </td></tr>
+        <tr><th><?php esc_html_e('Publishable key','reeserva');?></th><td><input type="text" name="stripe_pk" value="<?php echo esc_attr($p['stripe_pk']);?>" class="regular-text"></td></tr>
+        <tr><th><?php esc_html_e('Secret key','reeserva');?></th><td><input type="text" name="stripe_sk" value="<?php echo esc_attr($p['stripe_sk']);?>" class="regular-text"></td></tr>
+        <tr><th><?php esc_html_e('Test mode','reeserva');?></th><td><label><input type="checkbox" name="test_mode" <?php checked($p['test_mode']);?>> <?php esc_html_e('Use test keys','reeserva');?></label></td></tr>
+      </tbody></table>
+      <h2><?php esc_html_e('PayPal','reeserva');?></h2>
+      <p><label><input type="checkbox" name="paypal_enabled" <?php checked($p['paypal_enabled']);?>> <?php esc_html_e('Enable PayPal payments','reeserva');?></label></p>
+      <table class="form-table"><tbody>
+        <tr><th><?php esc_html_e('PayPal email','reeserva');?></th><td><input type="email" name="paypal_email" value="<?php echo esc_attr($p['paypal_email']);?>" class="regular-text"></td></tr>
+      </tbody></table>
+      <h2><?php esc_html_e('Pay on arrival','reeserva');?></h2>
+      <p><label><input type="checkbox" name="arrival_enabled" <?php checked($p['arrival_enabled']);?>> <?php esc_html_e('Enable pay on arrival','reeserva');?></label></p>
+      <p><button type="submit" name="rsv_payment_save" class="button button-primary"><?php esc_html_e('Save payment settings','reeserva');?></button></p>
+      <p class="description"><?php esc_html_e('Tip: Create a Release tag (v1.x) on GitHub to ship updates.','reeserva');?></p>
+    </form>
+    <?php
+}
 
+function rsv_render_email_settings(){
+    if (!current_user_can('manage_options')) return;
     ?>
     <div class="wrap"><h1><?php esc_html_e('Email & Payments','reeserva');?></h1>
       <h2 class="nav-tab-wrapper">
@@ -74,60 +133,8 @@ function rsv_render_email_settings(){
         <a href="#payments" class="nav-tab" onclick="rsvTab(event,'payments')"><?php esc_html_e('Payments','reeserva');?></a>
       </h2>
 
-      <div id="tab-emails">
-        <form method="post">
-          <?php wp_nonce_field('rsv_email_settings'); ?>
-          <h2><?php esc_html_e('General','reeserva');?></h2>
-          <table class="form-table"><tbody>
-            <tr><th><?php esc_html_e('From name','reeserva');?></th><td><input type="text" name="from_name" value="<?php echo esc_attr($s['from_name']);?>" class="regular-text"></td></tr>
-            <tr><th><?php esc_html_e('From email','reeserva');?></th><td><input type="email" name="from_email" value="<?php echo esc_attr($s['from_email']);?>" class="regular-text"></td></tr>
-          </tbody></table>
-          <h2><?php esc_html_e('Guest email','reeserva');?></h2>
-          <p><label><input type="checkbox" name="guest_enabled" <?php checked($s['guest_enabled']);?>> <?php esc_html_e('Enable guest confirmation email','reeserva');?></label></p>
-          <table class="form-table"><tbody>
-            <tr><th><?php esc_html_e('Subject','reeserva');?></th><td><input type="text" name="guest_subject" value="<?php echo esc_attr($s['guest_subject']);?>" class="regular-text"></td></tr>
-            <tr><th><?php esc_html_e('Body','reeserva');?></th><td><textarea name="guest_body" rows="6" class="large-text code"><?php echo esc_textarea($s['guest_body']);?></textarea></td></tr>
-          </tbody></table>
-          <h2><?php esc_html_e('Admin email','reeserva');?></h2>
-          <p><label><input type="checkbox" name="admin_enabled" <?php checked($s['admin_enabled']);?>> <?php esc_html_e('Enable admin notification email','reeserva');?></label></p>
-          <table class="form-table"><tbody>
-            <tr><th><?php esc_html_e('Subject','reeserva');?></th><td><input type="text" name="admin_subject" value="<?php echo esc_attr($s['admin_subject']);?>" class="regular-text"></td></tr>
-            <tr><th><?php esc_html_e('Body','reeserva');?></th><td><textarea name="admin_body" rows="6" class="large-text code"><?php echo esc_textarea($s['admin_body']);?></textarea></td></tr>
-          </tbody></table>
-          <h2><?php esc_html_e('Footer','reeserva');?></h2>
-          <p><textarea name="footer" rows="3" class="large-text code"><?php echo esc_textarea($s['footer']);?></textarea></p>
-          <p><button type="submit" name="rsv_email_save" class="button button-primary"><?php esc_html_e('Save email settings','reeserva');?></button></p>
-        </form>
-      </div>
-
-      <div id="tab-payments" style="display:none">
-        <form method="post">
-          <?php wp_nonce_field('rsv_payment_settings'); ?>
-          <h2><?php esc_html_e('Stripe','reeserva');?></h2>
-          <p><label><input type="checkbox" name="stripe_enabled" <?php checked($p['stripe_enabled']);?>> <?php esc_html_e('Enable Stripe payments','reeserva');?></label></p>
-          <table class="form-table"><tbody>
-            <tr><th><?php esc_html_e('Currency','reeserva');?></th><td>
-              <select name="currency">
-                <?php foreach(['eur'=>'EUR','usd'=>'USD','gbp'=>'GBP'] as $k=>$v): ?>
-                  <option value="<?php echo esc_attr($k);?>" <?php selected($p['currency'],$k);?>><?php echo esc_html($v);?></option>
-                <?php endforeach; ?>
-              </select>
-            </td></tr>
-            <tr><th><?php esc_html_e('Publishable key','reeserva');?></th><td><input type="text" name="stripe_pk" value="<?php echo esc_attr($p['stripe_pk']);?>" class="regular-text"></td></tr>
-            <tr><th><?php esc_html_e('Secret key','reeserva');?></th><td><input type="text" name="stripe_sk" value="<?php echo esc_attr($p['stripe_sk']);?>" class="regular-text"></td></tr>
-            <tr><th><?php esc_html_e('Test mode','reeserva');?></th><td><label><input type="checkbox" name="test_mode" <?php checked($p['test_mode']);?>> <?php esc_html_e('Use test keys','reeserva');?></label></td></tr>
-          </tbody></table>
-          <h2><?php esc_html_e('PayPal','reeserva');?></h2>
-          <p><label><input type="checkbox" name="paypal_enabled" <?php checked($p['paypal_enabled']);?>> <?php esc_html_e('Enable PayPal payments','reeserva');?></label></p>
-          <table class="form-table"><tbody>
-            <tr><th><?php esc_html_e('PayPal email','reeserva');?></th><td><input type="email" name="paypal_email" value="<?php echo esc_attr($p['paypal_email']);?>" class="regular-text"></td></tr>
-          </tbody></table>
-          <h2><?php esc_html_e('Pay on arrival','reeserva');?></h2>
-          <p><label><input type="checkbox" name="arrival_enabled" <?php checked($p['arrival_enabled']);?>> <?php esc_html_e('Enable pay on arrival','reeserva');?></label></p>
-          <p><button type="submit" name="rsv_payment_save" class="button button-primary"><?php esc_html_e('Save payment settings','reeserva');?></button></p>
-          <p class="description"><?php esc_html_e('Tip: Create a Release tag (v1.x) on GitHub to ship updates.','reeserva');?></p>
-        </form>
-      </div>
+      <div id="tab-emails"><?php rsv_render_email_form(); ?></div>
+      <div id="tab-payments" style="display:none"><?php rsv_render_payment_form(); ?></div>
     </div>
     <script>
     function rsvTab(e,id){e.preventDefault();document.querySelectorAll('.nav-tab').forEach(t=>t.classList.remove('nav-tab-active'));


### PR DESCRIPTION
## Summary
- Add [rsv_admin_dashboard] shortcode displaying calendar, email, and payment settings
- Extract email and payment forms into reusable functions
- Style admin dashboard with responsive Airbnb-like sidebar and mobile slide-out menu

## Testing
- `php -l includes/frontend-admin.php`
- `php -l includes/settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68a0b9b291e883329a77eeab3f87a757