### PR TITLE
Enable image uploads with previews for new accommodations

### DIFF
--- a/assets/css/checkout.css
+++ b/assets/css/checkout.css
@@ -17,3 +17,5 @@
 .error { background:#fee2e2; color:#7f1d1d; border-radius:8px; padding:10px; }
 .confirm { text-align:center; padding:20px 10px; }
 .confirm .badge { width:56px; height:56px; background:#16a34a; color:#fff; border-radius:50%; display:inline-flex; align-items:center; justify-content:center; font-size:28px; margin-bottom:8px; }
+.gallery-preview { display:flex; flex-wrap:wrap; gap:8px; margin-top:10px; }
+.gallery-preview img { width:100px; border-radius:8px; object-fit:cover; }

--- a/assets/js/frontend-admin.js
+++ b/assets/js/frontend-admin.js
@@ -14,4 +14,21 @@ document.addEventListener('DOMContentLoaded',function(){
       if(sidebar.classList.contains('open')) sidebar.classList.remove('open');
     });
   });
+  var galleryInput=document.getElementById('rsv-gallery-input');
+  var preview=document.getElementById('rsv-gallery-preview');
+  if(galleryInput&&preview){
+    galleryInput.addEventListener('change',function(){
+      preview.innerHTML='';
+      Array.prototype.forEach.call(galleryInput.files,function(file){
+        if(!file.type.match('image')) return;
+        var reader=new FileReader();
+        reader.onload=function(e){
+          var img=document.createElement('img');
+          img.src=e.target.result;
+          preview.appendChild(img);
+        };
+        reader.readAsDataURL(file);
+      });
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- allow multiple image uploads for new accommodation gallery with server-side handling
- add preview of selected gallery images via frontend script
- style gallery preview thumbnails in wizard

## Testing
- `php -l includes/frontend-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1b8f93748833299443da3083f54fd