### PR TITLE
Treat missing prices as unavailable

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -85,7 +85,14 @@ function rsv_pricing_map_for_day($accomm_id, $day){
             }
         }
     }
-    $bp =  floatval(get_post_meta($rates[0]->ID ?? 0,'rsv_base_price',true) ?? 0);
+    if (empty($rates)) {
+        return ['periods'=>[], 'prices'=>[]];
+    }
+    $raw_bp = get_post_meta($rates[0]->ID,'rsv_base_price',true);
+    $bp = $raw_bp === '' ? 0 : floatval($raw_bp);
+    if ($bp <= 0) {
+        return ['periods'=>[], 'prices'=>[]];
+    }
     return ['periods'=>[1],'prices'=>[$bp]];
 }
 function rsv_nightly_price_for_day($accomm_id,$day,$total_nights){


### PR DESCRIPTION
## Summary
- Treat days without defined prices as unavailable by returning an empty pricing map when no rate or base price exists.

## Testing
- `php -l includes/helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1bd07c80483329417dcdb32b3b601