### PR TITLE
Expand booking confirmation details

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -13,6 +13,7 @@ function rsv_default_email_settings(){
         'admin_subject'    => __('New booking','reeserva'),
         'admin_body'       => __('New booking for {accommodation}: {guest_name}, {check_in} → {check_out}.','reeserva'),
         'footer'           => '',
+        'confirmation_text'=> '',
     ];
 }
 function rsv_get_email_settings(){
@@ -48,6 +49,7 @@ function rsv_render_email_form(){
         $s['admin_subject'] = sanitize_text_field($_POST['admin_subject'] ?? '');
         $s['admin_body']    = wp_kses_post($_POST['admin_body'] ?? '');
         $s['footer']        = wp_kses_post($_POST['footer'] ?? '');
+        $s['confirmation_text'] = wp_kses_post($_POST['confirmation_text'] ?? '');
         update_option('rsv_email_settings',$s);
         echo '<div class="updated"><p>'.esc_html__('Email settings saved.','reeserva').'</p></div>';
     }
@@ -71,12 +73,16 @@ function rsv_render_email_form(){
         <tr><th><?php esc_html_e('Subject','reeserva');?></th><td><input type="text" name="admin_subject" value="<?php echo esc_attr($s['admin_subject']);?>" class="regular-text"></td></tr>
         <tr><th><?php esc_html_e('Body','reeserva');?></th><td><textarea name="admin_body" rows="6" class="large-text code"><?php echo esc_textarea($s['admin_body']);?></textarea></td></tr>
       </tbody></table>
-      <h2><?php esc_html_e('Footer','reeserva');?></h2>
-      <p><textarea name="footer" rows="3" class="large-text code"><?php echo esc_textarea($s['footer']);?></textarea></p>
-      <p><button type="submit" name="rsv_email_save" class="button button-primary"><?php esc_html_e('Save email settings','reeserva');?></button></p>
-    </form>
-    <?php
-}
+        <h2><?php esc_html_e('Footer','reeserva');?></h2>
+        <p><textarea name="footer" rows="3" class="large-text code"><?php echo esc_textarea($s['footer']);?></textarea></p>
+        <h2><?php esc_html_e('On-page confirmation','reeserva');?></h2>
+        <table class="form-table"><tbody>
+          <tr><th><?php esc_html_e('Confirmation text','reeserva');?></th><td><textarea name="confirmation_text" rows="3" class="large-text code"><?php echo esc_textarea($s['confirmation_text']);?></textarea></td></tr>
+        </tbody></table>
+        <p><button type="submit" name="rsv_email_save" class="button button-primary"><?php esc_html_e('Save email settings','reeserva');?></button></p>
+      </form>
+      <?php
+  }
 
 function rsv_render_payment_form(){
     if (!current_user_can('manage_options')) return;

--- a/reeserva-booking-suite.php
+++ b/reeserva-booking-suite.php
@@ -3,14 +3,14 @@
 /**
  * Plugin Name: Reeserva Booking Suite
  * Description: Minimal base plugin with GitHub self-updater wired to simoneomedia/reeserva1.
- * Version: 1.1.3
+ * Version: 1.1.4
  * Author: Reeserva
  * Text Domain: reeserva
  * Update URI: https://github.com/simoneomedia/reeserva1
  */
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define('RSV_VER','1.1.3');
+define('RSV_VER','1.1.4');
 define('RSV_PATH', plugin_dir_path(__FILE__));
 define('RSV_URL',  plugin_dir_url(__FILE__));
 


### PR DESCRIPTION
## Summary
- show detailed booking confirmation with accommodation info and guest details
- add admin setting for custom confirmation text
- bump plugin version to 1.1.4

## Testing
- `php -l includes/settings.php`
- `php -l includes/shortcodes.php`
- `php -l reeserva-booking-suite.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1c9e33ac08332a8c1e01a9ed09987