### PR TITLE
Add house rules and room/bed management for accommodations

### DIFF
--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -18,6 +18,17 @@ function rsv_default_amenities(){
         'first_aid'   => __('First aid kit','reeserva'),
     ];
 }
+
+function rsv_default_bed_types(){
+    return [
+        'single' => __('Single bed','reeserva'),
+        'double' => __('Double bed','reeserva'),
+        'queen'  => __('Queen bed','reeserva'),
+        'king'   => __('King bed','reeserva'),
+        'sofa'   => __('Sofa bed','reeserva'),
+        'bunk'   => __('Bunk bed','reeserva'),
+    ];
+}
 function rsv_get_meta($post_id, $key, $default = null){
     $v = get_post_meta($post_id, $key, true);
     return ($v === '' || $v === null) ? $default : $v;


### PR DESCRIPTION
## Summary
- add default bed types
- support house rules, room counts and beds in admin meta box
- extend frontend accommodation wizard with house rules and room/bed controls

## Testing
- `php -l includes/helpers.php`
- `php -l includes/cpt.php`
- `php -l includes/frontend-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1e9804d9083328b876f50c8d8823a