### PR TITLE
Add Airbnb-style layout for accommodation posts

### DIFF
--- a/assets/css/accommodation.css
+++ b/assets/css/accommodation.css
@@ -1,0 +1,10 @@
+.rsv-accomm{max-width:800px;margin:0 auto;font-family:Arial,sans-serif;}
+.rsv-hero-wrap img{width:100%;height:auto;border-radius:12px;}
+.rsv-gallery{display:grid;grid-template-columns:repeat(auto-fill,minmax(150px,1fr));gap:10px;margin:20px 0;}
+.rsv-gallery img{width:100%;height:100%;object-fit:cover;border-radius:8px;}
+.rsv-desc{margin-top:20px;}
+.rsv-info{display:flex;gap:20px;flex-wrap:wrap;margin:20px 0;}
+.rsv-info p{margin:0;font-weight:bold;}
+.rsv-amenities{list-style:none;padding:0;margin:20px 0;display:grid;grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:8px;}
+.rsv-amenities li{background:#f7f7f7;padding:8px 12px;border-radius:6px;}
+#rsv-calendar{margin-top:30px;}

--- a/assets/js/single-accomm.js
+++ b/assets/js/single-accomm.js
@@ -1,0 +1,19 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    var el = document.getElementById('rsv-calendar');
+    if(!el || typeof FullCalendar === 'undefined') return;
+    var calendar = new FullCalendar.Calendar(el, {
+      initialView: 'dayGridMonth',
+      height: 'auto',
+      events: function(info, success){
+        fetch(RSV_SINGLE.ajax_url+'?action=rsv_get_booked&type_id='+RSV_SINGLE.id+'&nonce='+RSV_SINGLE.nonce)
+          .then(function(r){ return r.json(); })
+          .then(function(res){ success(res && res.success ? res.data : []); })
+          .catch(function(){ success([]); });
+      },
+      eventColor: '#ff5a5f',
+      displayEventTime: false
+    });
+    calendar.render();
+  });
+})();

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -4,6 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 // Booked days (red blocks) per accommodation
 add_action('wp_ajax_rsv_get_booked','rsv_get_booked');
+add_action('wp_ajax_nopriv_rsv_get_booked','rsv_get_booked');
 function rsv_get_booked(){
     check_ajax_referer('rsv_get_booked','nonce');
     $type_id = intval($_GET['type_id'] ?? 0);

--- a/includes/cpt.php
+++ b/includes/cpt.php
@@ -157,3 +157,44 @@ add_filter('the_content', function($content){
     $out .= '</ul>';
     return $content.$out;
 });
+
+// Replace accommodation content with custom layout
+add_filter('the_content', function($content){
+    if('rsv_accomm' !== get_post_type()) return $content;
+    $id = get_the_ID();
+    $gallery = (array) get_post_meta($id,'rsv_gallery',true) ?: [];
+    $max = intval(get_post_meta($id,'rsv_max_guests',true));
+    $checkin = get_post_meta($id,'rsv_checkin',true);
+    $checkout = get_post_meta($id,'rsv_checkout',true);
+    $amenities = (array) get_post_meta($id,'rsv_amenities',true) ?: [];
+    $amen_labels = array_intersect_key(rsv_default_amenities(), array_flip($amenities));
+    ob_start();
+    echo '<div class="rsv-accomm">';
+    $thumb = get_the_post_thumbnail($id,'large',['class'=>'rsv-hero']);
+    if($thumb){ echo '<div class="rsv-hero-wrap">'.$thumb.'</div>'; }
+    if($gallery){ echo '<div class="rsv-gallery">'; foreach($gallery as $url){ echo '<img src="'.esc_url($url).'" alt="">'; } echo '</div>'; }
+    echo '<div class="rsv-desc">'.$content.'</div>';
+    echo '<div class="rsv-info">';
+    if($max){ echo '<p>'.sprintf(esc_html__('Max guests: %d','reeserva'), $max).'</p>'; }
+    if($checkin){ echo '<p>'.sprintf(esc_html__('Check-in: %s','reeserva'), esc_html($checkin)).'</p>'; }
+    if($checkout){ echo '<p>'.sprintf(esc_html__('Check-out: %s','reeserva'), esc_html($checkout)).'</p>'; }
+    echo '</div>';
+    if($amen_labels){ echo '<ul class="rsv-amenities">'; foreach($amen_labels as $label){ echo '<li>'.esc_html($label).'</li>'; } echo '</ul>'; }
+    echo '<div id="rsv-calendar"></div>';
+    echo '</div>';
+    return ob_get_clean();
+},20);
+
+// Enqueue assets for accommodation layout
+add_action('wp_enqueue_scripts', function(){
+    if(!is_singular('rsv_accomm')) return;
+    wp_enqueue_style('rsv-accommodation', RSV_URL.'assets/css/accommodation.css', [], RSV_VER);
+    wp_enqueue_style('fullcalendar', 'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/main.min.css', [], '6.1.11');
+    wp_enqueue_script('fullcalendar', 'https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js', [], '6.1.11', true);
+    wp_enqueue_script('rsv-accommodation', RSV_URL.'assets/js/single-accomm.js', ['fullcalendar'], RSV_VER, true);
+    wp_localize_script('rsv-accommodation', 'RSV_SINGLE', [
+        'ajax_url' => admin_url('admin-ajax.php'),
+        'nonce'    => wp_create_nonce('rsv_get_booked'),
+        'id'       => get_the_ID(),
+    ]);
+});


### PR DESCRIPTION
## Summary
- Replace accommodation content with an Airbnb-like layout displaying hero image, gallery, info, amenities, and an availability calendar
- Load availability via public AJAX endpoint and render calendar with FullCalendar
- Add styles and scripts for new front-end layout

## Testing
- `php -l includes/ajax.php`
- `php -l includes/cpt.php`


------
https://chatgpt.com/codex/tasks/task_e_68a1ed22124c8332a4e5bc376739f8f7